### PR TITLE
feat(ui): implement T-045 data reset page with confirmation

### DIFF
--- a/frontend/src/pages/DataResetPage.test.tsx
+++ b/frontend/src/pages/DataResetPage.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import DataResetPage from './DataResetPage'
+
+describe('DataResetPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 204 })))
+  })
+
+  it('requires confirmation before reset and calls reset endpoint after confirmation', async () => {
+    render(<DataResetPage />)
+
+    const resetButton = screen.getByRole('button', { name: 'Reset all data' })
+    expect(resetButton).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('checkbox'))
+    expect(resetButton).toBeEnabled()
+
+    fireEvent.click(resetButton)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    const requestUrl = new URL(String((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]))
+    expect(requestUrl.pathname).toBe('/reset')
+
+    expect(
+      screen.getByText('All demo data has been cleared.'),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/DataResetPage.tsx
+++ b/frontend/src/pages/DataResetPage.tsx
@@ -1,8 +1,67 @@
+import { useState } from 'react'
+import { resetData } from '../api'
+
 export default function DataResetPage() {
+  const [isConfirmed, setIsConfirmed] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  async function handleReset() {
+    if (!isConfirmed) {
+      return
+    }
+
+    setIsSubmitting(true)
+    setErrorMessage(null)
+    setSuccessMessage(null)
+
+    try {
+      await resetData()
+      setSuccessMessage('All demo data has been cleared.')
+      setIsConfirmed(false)
+    } catch {
+      setErrorMessage('Failed to reset data. Please try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
-    <section className="space-y-2">
-      <h1 className="text-xl font-semibold">Data Reset</h1>
-      <p className="text-sm">No data to reset yet.</p>
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-xl font-semibold">Data Reset</h1>
+        <p className="text-sm text-gray-700">
+          This action removes all transactions, recurring transactions, and recurrence rules.
+        </p>
+      </header>
+
+      <section className="space-y-4 rounded border p-4">
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            checked={isConfirmed}
+            type="checkbox"
+            onChange={(event) => {
+              setIsConfirmed(event.target.checked)
+            }}
+          />
+          <span>I understand this action cannot be undone.</span>
+        </label>
+
+        <button
+          className="rounded border px-3 py-1 text-sm font-medium disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={!isConfirmed || isSubmitting}
+          type="button"
+          onClick={() => {
+            void handleReset()
+          }}
+        >
+          {isSubmitting ? 'Resetting...' : 'Reset all data'}
+        </button>
+
+        {errorMessage ? <p className="text-sm text-red-700">{errorMessage}</p> : null}
+        {successMessage ? <p className="text-sm text-green-700">{successMessage}</p> : null}
+      </section>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
Implements task **T-045 [UI] Data reset page**.

## What changed
- Replaced placeholder with confirmation-based reset flow in [frontend/src/pages/DataResetPage.tsx](frontend/src/pages/DataResetPage.tsx):
  - Explicit confirmation checkbox required before reset
  - `Reset all data` action calling `/reset`
  - Loading state while request is in progress
  - Success and error feedback messages
- Added UI regression test in [frontend/src/pages/DataResetPage.test.tsx](frontend/src/pages/DataResetPage.test.tsx):
  - Verifies reset is disabled before confirmation
  - Verifies `/reset` is called after confirmation
  - Verifies success message is shown

## Acceptance coverage
- Confirmation required: implemented.
- Data reset action callable from UI: implemented.

## Validation
- `npm run test:run`
- `npm run lint`
- `npm run build`

All checks pass.